### PR TITLE
Remove check for 200 in client request

### DIFF
--- a/ranger_http/client.go
+++ b/ranger_http/client.go
@@ -51,11 +51,6 @@ func (client *apiClient) Do(req *http.Request) (*http.Response, error) {
 			"ApiClient.Do=Cannot execute request, URL=%s, Header=%+v", req.URL, req.Header,
 		)
 	}
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf(
-			"ApiClient.Do=Bad request,StatusCode=%d, URL=%s, Header: %+v", res.StatusCode, req.URL, res.Header,
-		)
-	}
 
 	return res, err
 }


### PR DESCRIPTION
It does not make sense to do that here, otherwise we would need to check for all 2xx statuses because they are all valid. This is responsibility of the client using the library.