### PR TITLE
Add full request dump to HTTP middleware

### DIFF
--- a/ranger_http/middleware.go
+++ b/ranger_http/middleware.go
@@ -2,11 +2,11 @@ package ranger_http
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"time"
 
 	"github.com/foodora/go-ranger/ranger_logger"
-	"net/http/httputil"
 )
 
 //MiddlewareInterface
@@ -31,7 +31,7 @@ func LoggerMiddleware(next http.Handler) http.Handler {
 					"method":  r.Method,
 					"URI":     r.RequestURI,
 					"time":    time.Since(start),
-					"request": getRequestDump(r),
+					"body": getRequestBody(r),
 				},
 			)
 		}()
@@ -42,12 +42,12 @@ func LoggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-//getRequestDump - Get a pretty print request or empty string
-func getRequestDump(r *http.Request) string {
-	d, err := httputil.DumpRequest(r, true)
+//getRequestBody - Get a pretty print request or empty string
+func getRequestBody(r *http.Request) string {
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return ""
 	}
 
-	return string(d)
+	return string(body)
 }

--- a/ranger_http/middleware.go
+++ b/ranger_http/middleware.go
@@ -42,7 +42,7 @@ func LoggerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
-//getRequestBody - Get a pretty print request or empty string
+//getRequestBody - Get a pretty print request body or empty string
 func getRequestBody(r *http.Request) string {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/ranger_http/middleware.go
+++ b/ranger_http/middleware.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/foodora/go-ranger/ranger_logger"
+	"net/http/httputil"
 )
 
 //MiddlewareInterface
@@ -27,9 +28,10 @@ func LoggerMiddleware(next http.Handler) http.Handler {
 			logger.Debug(
 				message.String(),
 				ranger_logger.LoggerData{
-					"method": r.Method,
-					"URI":    r.RequestURI,
-					"time":   time.Since(start),
+					"method":  r.Method,
+					"URI":     r.RequestURI,
+					"time":    time.Since(start),
+					"request": getRequestDump(r),
 				},
 			)
 		}()
@@ -38,4 +40,14 @@ func LoggerMiddleware(next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(fn)
+}
+
+//getRequestDump - Get a pretty print request or empty string
+func getRequestDump(r *http.Request) string {
+	d, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		return ""
+	}
+
+	return string(d)
 }


### PR DESCRIPTION
For debug purpose we should log the whole request.