### PR TITLE
Put the exactly error in fmt error returning

### DIFF
--- a/ranger_http/client.go
+++ b/ranger_http/client.go
@@ -47,7 +47,7 @@ func (client *apiClient) Do(req *http.Request) (*http.Response, error) {
 	res, err := client.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"ApiClient.Do=Cannot execute request, URL=%s, Header=%+v", req.URL, req.Header,
+			"ApiClient.Do=Cannot execute request, URL=%s, Header=%+v, error:%s", req.URL, req.Header, err,
 		)
 	}
 


### PR DESCRIPTION
[POST-980](https://foodpanda.atlassian.net/browse/POST-980)

Just return the original error also after formatted, as a developer, I need to know the exact error.