### PR TITLE
Change the log with remote address to header[X-Forwarded-For]

### DIFF
--- a/ranger_logger/logrus.go
+++ b/ranger_logger/logrus.go
@@ -71,7 +71,7 @@ func NewLogger(out io.Writer, appData LoggerData, f Formatter, logLevel string, 
 //CreateFieldsFromRequest - Create a logrus.Fields object from a Request
 func CreateFieldsFromRequest(r *http.Request) LoggerData {
 	return LoggerData{
-		"client_ip":      r.RemoteAddr,
+		"client_ip":      r.Header.Get("X-Forwarded-For"),
 		"request_method": r.Method,
 		"request_uri":    r.RequestURI,
 		"request_host":   r.Host,


### PR DESCRIPTION
Problem:
    The log for client ip in ranger_logger was set to remote address.  The remote address is composed 
    of {ip}:{port}. Because of this structure, kibana is not able to parse the log and therefore, these logs 
    are not shown on the platform.

Proposition:
    Just change the remoteAddr to X-Forwarded-For http header field. As shown in the changes of this 
    pull request.
  