### PR TITLE
Add extra fields prefix

### DIFF
--- a/ranger_logger/logrus.go
+++ b/ranger_logger/logrus.go
@@ -130,12 +130,17 @@ func (logger *Wrapper) GetAllFieldsToLog(data LoggerData) LoggerData {
 		result[k] = v
 	}
 
-	if logger.ExtraDataPrefix != "" {
-		result[logger.ExtraDataPrefix] = data
-	} else {
-		for k, v := range data {
+	ctx := LoggerData{}
+	for k, v := range data {
+		if _, ok := result[k]; !ok && logger.ExtraDataPrefix != "" {
+			ctx[k] = v
+		} else {
 			result[k] = v
 		}
+	}
+
+	if len(ctx) > 0 {
+		result[logger.ExtraDataPrefix] = ctx
 	}
 
 	return result

--- a/ranger_logger/logrus.go
+++ b/ranger_logger/logrus.go
@@ -1,7 +1,6 @@
 package ranger_logger
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 
@@ -125,18 +124,15 @@ func convertToLogrusFields(loggerData LoggerData) logrus.Fields {
 
 //GetAllFieldsToLog – merges default fields with the given ones
 func (logger *Wrapper) GetAllFieldsToLog(data LoggerData) LoggerData {
-	result := make(LoggerData)
+	var result LoggerData
+	copy(result, logger.DefaultData)
 
-	for k, v := range logger.DefaultData {
-		result[k] = v
-	}
-
-	for k, v := range data {
-		if logger.ExtraDataPrefix != "" {
-			k = fmt.Sprintf("%s.%s", logger.ExtraDataPrefix, k)
+	if logger.ExtraDataPrefix != "" {
+		result[logger.ExtraDataPrefix] = data
+	} else {
+		for k, v := range data {
+			result[k] = v
 		}
-
-		result[k] = v
 	}
 
 	return result

--- a/ranger_logger/logrus.go
+++ b/ranger_logger/logrus.go
@@ -1,6 +1,7 @@
 package ranger_logger
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 
@@ -24,8 +25,9 @@ type LoggerInterface interface {
 
 //Wrapper - Wrap a logrus logger
 type Wrapper struct {
-	*logrus.Logger            // see promoted methods https://www.goinggo.net/2015/09/composition-with-go.html,
-	AppData        LoggerData // default fields
+	*logrus.Logger             // see promoted methods https://www.goinggo.net/2015/09/composition-with-go.html,
+	DefaultData     LoggerData // default fields
+	ExtraDataPrefix string
 }
 
 // JSONFormatter Wrapper for logrus.JSONFormatter
@@ -65,7 +67,7 @@ func NewLogger(out io.Writer, appData LoggerData, f Formatter, logLevel string, 
 		}
 	}
 
-	return &Wrapper{log, appData}
+	return &Wrapper{log, appData, ""}
 }
 
 //CreateFieldsFromRequest - Create a logrus.Fields object from a Request
@@ -125,13 +127,21 @@ func convertToLogrusFields(loggerData LoggerData) logrus.Fields {
 func (logger *Wrapper) GetAllFieldsToLog(data LoggerData) LoggerData {
 	result := make(LoggerData)
 
-	for k, v := range logger.AppData {
+	for k, v := range logger.DefaultData {
 		result[k] = v
 	}
 
 	for k, v := range data {
+		if logger.ExtraDataPrefix != "" {
+			k = fmt.Sprintf("%s.%s", logger.ExtraDataPrefix, k)
+		}
+
 		result[k] = v
 	}
 
 	return result
+}
+
+func (logger *Wrapper) SetPrefix(p string) {
+	logger.ExtraDataPrefix = p
 }

--- a/ranger_logger/logrus.go
+++ b/ranger_logger/logrus.go
@@ -124,8 +124,11 @@ func convertToLogrusFields(loggerData LoggerData) logrus.Fields {
 
 //GetAllFieldsToLog – merges default fields with the given ones
 func (logger *Wrapper) GetAllFieldsToLog(data LoggerData) LoggerData {
-	var result LoggerData
-	copy(result, logger.DefaultData)
+	result := make(LoggerData)
+
+	for k, v := range logger.DefaultData {
+		result[k] = v
+	}
 
 	if logger.ExtraDataPrefix != "" {
 		result[logger.ExtraDataPrefix] = data


### PR DESCRIPTION
As foodora Kibana implementation uses a prefix to enable unknown fields to be used in filters, I'm adding a new field in the log wrapper.

How to use it:
```go
logger := ranger_logger.NewLogger(
    os.Stdout,
    ranger_logger.LoggerData{
        "env":           Env.Environment,
        "appName": Env.AppName,
    },
    ranger_logger.GetJSONFormatter(),
    Env.LogLevel,
)

logger.(*ranger_logger.Wrapper).SetPrefix("ctx")
```