### PR TITLE
ranger metrics: add newrelic trans to request context

### DIFF
--- a/ranger_metrics/newrelic.go
+++ b/ranger_metrics/newrelic.go
@@ -60,6 +60,9 @@ func (newRelic *NewRelic) Middleware(next http.Handler) http.Handler {
 		txn := newRelic.Application.StartTransaction(r.URL.Path, w, r)
 		defer txn.End()
 
+		ctx := newrelic.NewContext(r.Context(), txn)
+		r = r.WithContext(ctx)
+
 		next.ServeHTTP(txn, r)
 	}
 


### PR DESCRIPTION
To be able to add a newrelic custom parameter, we forward a newrelic transaction instance through a request context