### PR TITLE
Add received count getter to Message struct

### DIFF
--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/foodora/go-ranger/pubsub"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -177,6 +178,19 @@ func (m *subscriberMessage) Done() error {
 		receipt: receipt,
 	}
 	return <-receipt
+}
+
+// Returns the number of times a message has been received from the queue but not deleted.
+func (m *subscriberMessage) GetReceiveCount() int {
+	val, ok := m.message.Attributes[sqs.MessageSystemAttributeNameApproximateReceiveCount]
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(*val)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // Start will start consuming messages on the SQS queue

--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -215,10 +215,12 @@ func (s *subscriber) Start() <-chan pubsub.Message {
 			}
 			s.Logger.Printf("receiving messages")
 			// get messages
+			nameApproximateReceiveCount := sqs.MessageSystemAttributeNameApproximateReceiveCount
 			resp, err = s.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{
 				MaxNumberOfMessages: aws.Int64(s.cfg.MaxMessages),
 				QueueUrl:            s.queueURL,
-				WaitTimeSeconds:     s.cfg.TimeoutSeconds,
+				WaitTimeSeconds:     s.cfg.TimeoutSeconds, //MessageSystemAttributeNameApproximateReceiveCount
+				AttributeNames:      []*string{&nameApproximateReceiveCount},
 			})
 			if err != nil {
 				// we've encountered a major error

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -26,4 +26,5 @@ type Message interface {
 	String() string
 	ExtendDoneDeadline(time.Duration) error
 	Done() error
+	GetReceiveCount() int
 }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -26,5 +26,5 @@ type Message interface {
 	String() string
 	ExtendDoneDeadline(time.Duration) error
 	Done() error
-	GetReceiveCount() int
+	GetReceiveCount() (int, error)
 }


### PR DESCRIPTION
To handle cases when a message was read from a queue several times we should and an attribute to the request to sqs and expose a getter for that value.