### PR TITLE
bugfix: deadlock; flush delete buffer after stopping the subscriber

### DIFF
--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -291,6 +291,7 @@ func (s *subscriber) handleDeletes() {
 	}
 }
 
+// deleteMessageBatch is helper function to remove messages from sqs in batches
 func (s *subscriber) deleteMessageBatch(batchReq ...*sqs.DeleteMessageBatchRequestEntry) error {
 	batchInput := &sqs.DeleteMessageBatchInput{
 		QueueUrl: s.queueURL,

--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -251,11 +251,16 @@ func (s *subscriber) Start() <-chan pubsub.Message {
 			s.Logger.Printf("found %d messages", len(resp.Messages))
 			// for each message, pass to output
 			for _, msg := range resp.Messages {
-				output <- &subscriberMessage{
+				select {
+				case exit := <-s.stop:
+					exit <- nil
+					return
+				case output <- &subscriberMessage{
 					sub:     s,
 					message: msg,
+				}:
+					s.incrementInFlight()
 				}
-				s.incrementInFlight()
 			}
 		}
 	}()


### PR DESCRIPTION
few fixes related to aws subscriber:
- deadlock occurs if the subscriber is stopped and received messages from aws waiting for a space in output channel, at that a consumer does not read from the output channel as it has stopped the subscriber.
- removed messages are not flushed from the buffer after the subscriber is stopped and as a result handled and removed messages are not removed from sqs queue.
- err var is not set to nil after each delete iteration.
- stop all goroutine when the subscriber is being stopped
- do not add a removed message to delete buffer if the subscriber is not running 