### PR TITLE
Aws subscriber logs with an error level when the call to sqs fails

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB818
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eYfc3yylgNZACZqkM=
-github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/newrelic/go-agent v2.7.0+incompatible h1:T5tJ9nNY1bXBfLUTCEZRuBLPT0f9+mE1jd4EaNoN5Zs=
 github.com/newrelic/go-agent v2.7.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea h1:sKwxy1H95npauwu8vtF95vG/syrL0p8fSZo/XlDg5gk=

--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -378,10 +378,12 @@ func (s *subscriber) Err() error {
 func (s *subscriber) log(level logLevel, format string, args ...interface{}) {
 	if level == logLevelDebug {
 		s.Logger.Printf(format, args)
+		return
 	}
 	logger, ok := s.Logger.(pubsub.ErrorLogger)
 	if level == logLevelError && ok {
 		logger.Error(append([]interface{}{format}, args...))
+		return
 	}
 	s.Logger.Printf(format, args)
 }

--- a/pubsub/awssub/sub_test.go
+++ b/pubsub/awssub/sub_test.go
@@ -224,7 +224,7 @@ func TestExtendDoneTimeout(t *testing.T) {
 }
 
 func TestLogError(t *testing.T) {
-	logger := &testLogger{}
+	logger := &loggerMock{}
 	pubsub.SetLogger(logger)
 	sqstest := &TestSQSAPI{
 		Messages: [][]*sqs.Message{},
@@ -255,17 +255,17 @@ func TestLogError(t *testing.T) {
 	}
 }
 
-// testLogger logger mock
-type testLogger struct {
+// loggerMock logger mock
+type loggerMock struct {
 	errorCallCount uint64
 }
 
 // Printf ...
-func (l *testLogger) Printf(format string, v ...interface{}) {
+func (l *loggerMock) Printf(format string, v ...interface{}) {
 }
 
 // Error ...
-func (l *testLogger) Error(args ...interface{}) {
+func (l *loggerMock) Error(args ...interface{}) {
 	atomic.AddUint64(&l.errorCallCount, 1)
 }
 

--- a/pubsub/logger.go
+++ b/pubsub/logger.go
@@ -10,6 +10,11 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
+// ErrorLogger logs with an error level
+type ErrorLogger interface {
+	Error(args ...interface{})
+}
+
 // DefaultLogger will be used as logger when create a new server using NewServer()
 var DefaultLogger Logger
 


### PR DESCRIPTION
The current logger interface which is used by aws subscriber defines one function `Printf` that does not give a way to log with different log levels such as `error`.
In order to provide an error level logging for errors coming from sqs client we introduce new `ErrorLogger` interface without changing the api for clients and using a type assertion for backward compatibility.
