### PR TITLE
Fix empty request body issue

### DIFF
--- a/fdhttp/router.go
+++ b/fdhttp/router.go
@@ -232,7 +232,7 @@ func (r *Router) Handler(method, path string, fn EndpointFunc) *Endpoint {
 		handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := req.Context()
 			ctx = SetRouteParams(ctx, convertParams(ps))
-
+			ctx = SetRequest(ctx, req)
 			ctx, err := injectRequestBody(ctx, req)
 			if err != nil {
 				ResponseJSON(w, http.StatusBadRequest, &Error{
@@ -330,7 +330,6 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	ctx := req.Context()
-	ctx = SetRequest(ctx, req)
 	ctx = SetRequestHeader(ctx, req.Header)
 
 	ctx = SetResponse(ctx, w)


### PR DESCRIPTION
Issue description:
Currently, to get the request from context, we do it like `fdhttp.Request(ctx)` but if you tried to access this request body or params, you'll find it empty.
for example, if you try to do the following
```
request := fdhttp.Request(context)
data, _ := ioutil.ReadAll(request.Body)
fmt.Println(string(empty))
```
you'll always receive an empty body

Issue details:
Currently, we set the request body in the HTTPServe() method `https://github.com/foodora/go-ranger/blob/2b6f1bd410f72b191bebe2163f5831ced6d9550e/fdhttp/router.go#L333`
and at this point, the request object still has no request body (request body is being set in the request handler)