### PR TITLE
Awssub remove a redundant debug log

### DIFF
--- a/pubsub/awssub/sub.go
+++ b/pubsub/awssub/sub.go
@@ -249,7 +249,6 @@ func (s *subscriber) Start() <-chan pubsub.Message {
 				return
 			default:
 			}
-			s.Logger.Printf("receiving messages")
 			// get messages
 			nameApproximateReceiveCount := sqs.MessageSystemAttributeNameApproximateReceiveCount
 			resp, err = s.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{


### PR DESCRIPTION
Awssub remove a redundant debug log as was suggested here https://github.com/foodora/go-ranger/pull/71