### PR TITLE
Add setter for on error func handler

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -19,6 +19,8 @@ type Subscriber interface {
 	Err() error
 	// Stop will initiate a graceful shutdown of the subscriber connection.
 	Stop() error
+	// SetOnErrorFunc is a setter for a func is being called when an error occurs
+	SetOnErrorFunc(fn func(error))
 }
 
 // Message ...


### PR DESCRIPTION
In the previous PR we introduced an error handler function for aws subscriber but missed to add a setter for it to the aws subscriber interface.
In this PR we adding it.